### PR TITLE
replace deprecated with_first_found

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,10 @@
 ---
 - name: Gather OS specific variables
   include_vars: "{{ loop_vars }}"
-  with_first_found:
-    - files:
+  loop: "{{ query('first_found', params) }}"
+  vars:
+    params:
+      files:
         - "{{ ansible_distro }}-{{ ansible_distro_version }}.yml"
         - "{{ ansible_distro }}-{{ ansible_distro_release }}.yml"
         - "{{ ansible_distro }}-{{ ansible_distro_major_version }}.yml"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Ansible loops `with_*` are deprecated, this PR uses `loop` and `first_found`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Molecule coverage

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
Deprecated feature

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
