### PR TITLE
Fix: allow passing update password args when creating users

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -6,6 +6,8 @@ on:  # yamllint disable-line rule:truthy
     tags_ignore:
       - '*'
   pull_request:
+  schedule:
+    - cron: '0 0 1 */3 *'
 
 jobs:
   setup:

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ See [tasks/install.yml](tasks/install.yml).
           id_rsa:
             public: 'ssh-rsa '
             private: "{{ lookup('community.hashi_vault.hashi_vault', 'secret/ssh:private_key') }}"
+        update_password: "on_create"         # default is always
 ```
 
 ## :closed_lock_with_key: [Hardening](HARDENING.md)

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,8 +1,9 @@
 ---
 dependency:
   name: shell
-  command: python3 -m pip install pytest-testinfra
-
+  command: |
+    pip install requests pytest-testinfra &&
+    ansible-galaxy collection install community.crypto community.general
 driver:
   name: docker
 
@@ -27,6 +28,9 @@ provisioner:
   name: ansible
   env:
     ANSIBLE_FORCE_COLOR: "true"
+    ANSIBLE_LOAD_CALLBACK_PLUGINS: "true"
+    ANSIBLE_CALLBACKS_ENABLED: "ansible.posix.profile_tasks"
+    ANSIBLE_STDOUT_CALLBACK: "ansible.posix.debug"
   options:
     v: true
 

--- a/tasks/create_users.yml
+++ b/tasks/create_users.yml
@@ -15,3 +15,4 @@
     uid: "{{ item.value.uid | default(omit) }}"
     group: "{{ item.value.group | default(omit) }}"
     groups: "{{ item.value.groups | default(omit) }}"
+    update_password: "{{ item.value.update_password | default(omit) }}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add update password args when creating users

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Avoid changes at every runs when creating users because update_password policy is by default to always

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Using molecule scenario


## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] feat: add schedule for run workflow each three months
- [x] feat: allow settings update_password policy options when creating users
- [x] feat: load ansible callback for display scenario exec time

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires change to the documentation.

#12 
